### PR TITLE
fix: refactor pipeline to use latest templates

### DIFF
--- a/.azure-pipelines/beta-build-production.yml
+++ b/.azure-pipelines/beta-build-production.yml
@@ -1,27 +1,85 @@
-# Production build pipeline preparing for npm publish
-
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
+# This pipeline will be extended to the OneESPT template
+# The pool section has been filled with placeholder values, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 trigger:
-  - main
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - microsoft-graph.d.ts
+pr: none
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-latest
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      jobs:
+      - job: job
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact drop'
+            targetPath: '$(Build.ArtifactStagingDirectory)'
+            artifactName: build-drop
+        steps:
+        - checkout: self
+          displayName: checkout main
+        - task: CopyFiles@2
+          displayName: 'Copy Files to staging directory'
+          inputs:
+            SourceFolder: '$(System.DefaultWorkingDirectory)'
+            Contents: |
+              **/*
+              !spec/**
+              !.azure-pipelines/**
+              !.github/**
+              !.git/**
+              !.vscode/**
+              !typings-demo.gif
+            TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
-pool:
-  vmImage: ubuntu-latest
 
-steps:
-
-- script: git checkout main
-- task: CopyFiles@2
-  displayName: 'Copy Files to staging directory'
-  inputs:
-    SourceFolder: '$(System.DefaultWorkingDirectory)'
-    Contents: |
-     **/*
-     !spec/**
-     !.azure-pipelines/**
-     !.github/**
-     !.git/**
-     !.vscode/**
-     !typings-demo.gif
-    TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: drop'
+    - stage: deploy
+      condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+      jobs:
+        - deployment: deploy_npm
+          pool:
+            name: Azure-Pipelines-1ESPT-ExDShared
+            os: windows
+            image: windows-latest
+          dependsOn: []
+          environment: msgraph-npm-org
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                - download: current
+                  artifact: build-drop
+                - task: EsrpRelease@5
+                  inputs:
+                    ConnectedServiceName: 'MsGraph-ESRP-Publisher-Service-Connection'
+                    Intent: 'PackageDistribution'
+                    ContentType: 'npm'
+                    ContentSource: 'Folder'
+                    FolderLocation: $(Pipeline.Workspace)/build-drop/
+                    WaitForReleaseCompletion: true
+                    Owners: '3PMSGraphDevxTeam@microsoft.com'
+                    Approvers: 'anomondi@microsoft.com,ronaldkudoyi@microsoft.com,pgichuhi@microsoft.com,shemogumbe@microsoft.com'
+                    ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+                    MainPublisher: 'ESRPRELPACMAN'
+                    DomainTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'


### PR DESCRIPTION
Replication of 

Ensures pipelines are using governed templates and latest esrp release tasks. Also moves deploy task to be in the yaml format to move away from the release UI.

Fixes https://github.com/microsoftgraph/msgraph-beta-typescript-typings/issues/142